### PR TITLE
Scroll word list to top after clearing

### DIFF
--- a/src/word_tree.cpp
+++ b/src/word_tree.cpp
@@ -101,6 +101,7 @@ QTreeWidgetItem* WordTree::addWord(const QString& word) {
 void WordTree::removeAll() {
 	m_active_item = 0;
 	clear();
+	scrollToTop();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This small fix avoids an arbitrary position of the missed words list in next game if it was scrolled down in the last game.