### PR TITLE
Current item in word lists was not cleared

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -475,7 +475,9 @@ void Board::clearGuess() {
 	updateClickableStatus();
 	m_guess->clear();
 	m_found->clearSelection();
+	m_found->setCurrentItem(0);
 	m_missed->clearSelection();
+	m_missed->setCurrentItem(0);
 	m_guess->setFocus();
 	updateButtons();
 }
@@ -777,6 +779,7 @@ void Board::selectGuess() {
 		m_found->scrollToItem(item, QAbstractItemView::PositionAtCenter);
 	} else {
 		m_found->clearSelection();
+		m_found->setCurrentItem(0);
 	}
 }
 


### PR DESCRIPTION
This small fix also clears the current item in the word lists when the selection is cleared. At least on some platforms (Linux), the current item is visually marked (light blue background vs. dark blue for a selection), which is probably not wanted when the selection is cleared.

For example at the end of a game, the last guess is cleared in the text field and on the game board and it is not very meaningful and a bit distracting to still have it marked in the list (if it was selected there because it already existed).