### PR TITLE
Automatically scroll found words to words matching selected letters.

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -548,6 +548,8 @@ void Board::guessChanged() {
 		int pos = m_guess->cursorPosition();
 		m_guess->setText(word);
 		m_guess->setCursorPosition(pos);
+		QTreeWidgetItem* item = m_found->findItems(word, Qt::MatchStartsWith, 2).value(0);
+		m_found->scrollToItem(item, QAbstractItemView::PositionAtTop);
 
 		Trie trie(word);
 		Solver solver(trie, m_size, 0);
@@ -662,6 +664,8 @@ void Board::letterClicked(Letter* letter) {
 		QString word = m_guess->text().trimmed().toUpper();
 		word.append(letter->text().toUpper());
 		m_guess->setText(word);
+		QTreeWidgetItem* item = m_found->findItems(word, Qt::MatchStartsWith, 2).value(0);
+		m_found->scrollToItem(item, QAbstractItemView::PositionAtTop);
 
 		m_wrong = false;
 		m_positions.append(letter->position());


### PR DESCRIPTION
I find myself having to manually scroll the found word list a lot during games to see what words I already found or missed. This is especially true for German, where verbs have lots of declined forms that all start with the same word stem and it is not easy to remember which ones were already found and which ones could still be found.

This patch makes sure that the found words list always scrolls to the position with the found words that match the currently selected letters.