### PR TITLE
Updated AppData installation directory.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -119,7 +119,7 @@ macx {
 	desktop.path = $$PREFIX/share/applications/
 
 	appdata.files = ../icons/tanglet.appdata.xml
-	appdata.path = $$PREFIX/share/appdata/
+        appdata.path = $$PREFIX/share/metainfo/
 
 	qm.files = ../translations/*.qm
 	qm.path = $$PREFIX/share/tanglet/translations


### PR DESCRIPTION
The installation directory for AppData files has changed according to the current AppStream specification [1] and the Debian AppStream guidelines [2]. Although AppStream tools are still required to scan /usr/share/appdata/ to support legacy applications, the old directory is now deprecated and AppData files should be installed to /usr/share/metainfo.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location
[2] https://wiki.debian.org/AppStream/Guidelines#General