### PR TITLE
Avoid unnecessary scrolling if item is already visible.

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -515,7 +515,7 @@ void Board::guess() {
 
 			m_counts->findWord(text);
 		}
-		m_found->scrollToItem(item, QAbstractItemView::PositionAtCenter);
+		m_found->scrollToItem(item);
 		m_found->setCurrentItem(nullptr);
 
 		// Clear guess
@@ -778,7 +778,7 @@ void Board::selectGuess() {
 	QTreeWidgetItem* item = m_found->findItems(m_guess->text(), Qt::MatchExactly, 0).value(0);
 	if (item != 0) {
 		m_found->setCurrentItem(item);
-		m_found->scrollToItem(item, QAbstractItemView::PositionAtCenter);
+		m_found->scrollToItem(item);
 	} else {
 		m_found->setCurrentItem(nullptr);
 	}


### PR DESCRIPTION
This is a proposed minor change to the scrolling behavior. It uses EnsureVisible (the default for QTreeWidget::scrollToItem) instead of PositionAtCenter.

This reduces unnecessary scrolling if a newly added word is already visible and works better with the recent change to show found words at the top that match the currently typed letters.