### PR TITLE
Accept words with i-circumflex in German wordlist

### DIFF
--- a/tools/wordlist/main.cpp
+++ b/tools/wordlist/main.cpp
@@ -65,6 +65,7 @@ QString generateSolutionDe(QString string)
 	string.replace(u'Ī', 'I');
 	string.replace(u'Í', 'I');
 	string.replace(u'Ï', 'I');
+	string.replace(u'Î', 'I');
 	string.replace(u'Ł', 'L');
 	string.replace(u'Ñ', 'N');
 	string.replace(u'Ō', 'O');


### PR DESCRIPTION
The German wordlist contains a word (Maître and its plural) that is not yet converted.