### PR TITLE
Convert oe-ligature and e-diaeresis in German words.

### DIFF
--- a/tools/wordlist/main.cpp
+++ b/tools/wordlist/main.cpp
@@ -52,6 +52,7 @@ QString generateSolutionDe(QString string)
 	string.replace(u'Ä', "AE");
 	string.replace(u'Ö', "OE");
 	string.replace(u'Ü', "UE");
+	string.replace(u'Œ', "OE");
 	string.replace(u'À', 'A');
 	string.replace(u'Á', 'A');
 	string.replace(u'Â', 'A');
@@ -62,6 +63,7 @@ QString generateSolutionDe(QString string)
 	string.replace(u'È', 'E');
 	string.replace(u'Ê', 'E');
 	string.replace(u'Ē', 'E');
+	string.replace(u'Ë', 'E');
 	string.replace(u'Ī', 'I');
 	string.replace(u'Í', 'I');
 	string.replace(u'Ï', 'I');


### PR DESCRIPTION
Needed for at least two words that are used in their unchanged French form in German ("Noël", "Cœur"). These words do not yet exist in the current tanglet repository but in the in the current wordlist in the german-wordlist repository.