### PR TITLE
Made window icon work on Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char** argv) {
 	app.setOrganizationName("GottCode");
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
 	app.setWindowIcon(QIcon::fromTheme("tanglet", QIcon(":/tanglet.png")));
+	QGuiApplication::setDesktopFileName("tanglet");
 #endif
 	app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,9 @@ int main(int argc, char** argv) {
 	app.setOrganizationName("GottCode");
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
 	app.setWindowIcon(QIcon::fromTheme("tanglet", QIcon(":/tanglet.png")));
+#if QT_VERSION >= QT_VERSION_CHECK(5,7,0)
 	QGuiApplication::setDesktopFileName("tanglet");
+#endif
 #endif
 	app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,8 @@ int main(int argc, char** argv) {
 	app.setWindowIcon(QIcon::fromTheme("tanglet", QIcon(":/tanglet.png")));
 #if QT_VERSION >= QT_VERSION_CHECK(5,7,0)
 	QGuiApplication::setDesktopFileName("tanglet");
+#else
+	app.setProperty("desktopFileName", "tanglet");
 #endif
 #endif
 	app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);


### PR DESCRIPTION
This patch makes the window icon work on Wayland. On Wayland, the compositor has no access to the window icon, but the application transmits the name of the desktop entry. By default, Qt guesses the name of the desktop entry using QCoreApplication::organizationDomain and the name of the executable. This currently doesn't work for Tanglet and it is probably better to explicitely set the name of the desktop entry anyway.

The new and old behavior can be tested on Ubunto 18.10 by installing gnome-session-wayland, selecting Ubuntu Wayland at the login screen (e.g. on an Intel IGP, Nvidia doesn't support Wayland) and running "QT_QPA_PLATFORM=wayland tanglet"