### PR TITLE
Avoid (shallow) copy of QList, which caused a clang-tidy performance …

### DIFF
--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -64,7 +64,7 @@ Solver::Solver(const Trie& words, int size, int minimum)
 			cell.position = QPoint(c,r);
 			cell.checked = false;
 
-			QList<QPoint> n = neighbors.at(index);
+			const auto& n = neighbors.at(index);
 			for (int i = 0; i < n.count(); ++i) {
 				const QPoint& neighbor = n.at(i);
 				cell.neighbors.append(&m_cells[neighbor.x()][neighbor.y()]);


### PR DESCRIPTION
Even if QList copies are cheap, there is no reason to make a copy here and it causes a warning when running clang-tidy (of type performance-unnecessary-copy-initialization).